### PR TITLE
fix: require python > 3.7

### DIFF
--- a/{{cookiecutter.project_name}}/pyproject.toml
+++ b/{{cookiecutter.project_name}}/pyproject.toml
@@ -7,7 +7,7 @@ license = "MIT"
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = ">=3.7"
+python = ">3.7"
 
 [tool.poetry.dev-dependencies]
 vulture = ">=1.0"


### PR DESCRIPTION
Fixes the dependency resolution issue during poetry install

```
  The current project's Python requirement (>=3.7) is not compatible with some of the required packages Python requirement:
    - portray requires Python >=3.6,<4.0, so it will not be satisfied for Python >=4.0
    - portray requires Python >=3.6,<4.0, so it will not be satisfied for Python >=4.0
    - portray requires Python >=3.6,<4.0, so it will not be satisfied for Python >=4.0
    - portray requires Python >=3.6,<4.0, so it will not be satisfied for Python >=4.0
    - portray requires Python >=3.6,<4.0, so it will not be satisfied for Python >=4.0
    - portray requires Python >=3.6,<4.0, so it will not be satisfied for Python >=4.0
    - portray requires Python >=3.6,<4.0, so it will not be satisfied for Python >=4.0
    - portray requires Python >=3.6,<4.0, so it will not be satisfied for Python >=4.0
    - portray requires Python >=3.6,<4.0, so it will not be satisfied for Python >=4.0
    - portray requires Python >3.7, so it will not be satisfied for Python 3.7
```